### PR TITLE
Fix firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -349,7 +349,6 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
 			"integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
-			"dev": true,
 			"requires": {
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.4"
@@ -1111,6 +1110,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
+		},
+		"@types/xregexp": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@types/xregexp/-/xregexp-4.3.0.tgz",
+			"integrity": "sha512-3gJTS9gt27pS7U9q5IVqo4YvKSlkf2ck8ish6etuDj6LIRxkL/2Y8RMUtK/QzvE1Yv2zwWV5yemI2BS0GGGFnA==",
 			"dev": true
 		},
 		"@types/yargs": {
@@ -4199,8 +4204,7 @@
 		"core-js-pure": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-			"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-			"dev": true
+			"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -11248,8 +11252,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-			"dev": true
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -14580,7 +14583,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
 			"integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime-corejs3": "^7.8.3"
 			}

--- a/package.json
+++ b/package.json
@@ -31,10 +31,6 @@
       "source/**/*.{js,ts,tsx}"
     ]
   },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
@@ -43,6 +39,7 @@
   "devDependencies": {
     "@sindresorhus/tsconfig": "^0.7.0",
     "@types/jest": "^25.2.1",
+    "@types/xregexp": "^4.3.0",
     "chrome-webstore-upload-cli": "^1.2.0",
     "copy-webpack-plugin": "^5.0.3",
     "daily-version": "^1.0.0",
@@ -69,6 +66,7 @@
   },
   "dependencies": {
     "webext-options-sync": "^1.2.3",
-    "webextension-polyfill-ts": "^0.14.0"
+    "webextension-polyfill-ts": "^0.14.0",
+    "xregexp": "^4.3.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,10 @@ Since this is all very concerning, but users are left with pretty much no choice
 - Per meeting bookmark settings (i.e. url prefixing)
 - Zoom meeting link extraction
 
+## Configuration
+
+For FireFox rights to run in private window, are mandatory to open a private window.
+
 ## Changelog
 
 To see the changes between versions have a look at the [changelog](https://github.com/s-weigand/zoomcognito/blob/master/CHANGELOG.md)

--- a/source/lib/browser_functions.ts
+++ b/source/lib/browser_functions.ts
@@ -1,8 +1,8 @@
 import { browser } from 'webextension-polyfill-ts'
 
 export const openInIncognitoWindow = (url: string): void => {
-  browser.windows.create({ incognito: true, url }).catch(() => {
-    alert(`Unable to open ${url}`)
+  browser.windows.create({ incognito: true, url }).catch((error: Error) => {
+    alert(`Unable to open ${url}\n\n ${error}`)
   })
 }
 
@@ -18,7 +18,7 @@ export const blockZoomClientDownload = (blockClientDownload: boolean) => {
     browser.webRequest.onBeforeRequest.addListener(
       blockZoomClientDownloadListener,
       { urls: ['*://*.zoom.us/downloads/*'] },
-      ['blocking']
+      ['blocking'],
     )
   }
 }

--- a/source/lib/parsers.ts
+++ b/source/lib/parsers.ts
@@ -1,21 +1,24 @@
+import XRegExp from 'xregexp'
+
 import { ImplementationError } from './errors'
 
 /**
  * Determines if an url is valid, to generate a zoom link
  */
 export const isZoomMeetingUrl = (url: string): boolean => {
-  const zoomMeetingUrlRegex = /^https?\:\/\/(.*\.)?zoom\.us\/(wc\/)?(?<mode1>(j|s|join|start)\/)?(\d+)(?<mode2>\/(join|start|j|s|))?/i
-  const matches = zoomMeetingUrlRegex.exec(url)
-  if (matches !== null) {
-    if (
-      matches.groups !== undefined &&
-      // tslint:disable-next-line: strict-type-predicates
-      (matches.groups.mode1 !== undefined || matches.groups.mode2 !== undefined)
-    ) {
-      return true
-    } else {
-      return false
-    }
+  const zoomMeetingUrlRegex = XRegExp(
+    `^https?://
+    (sub-domain\\.)?
+    zoom\\.us/
+    (wc/)?
+    (?<mode1>(j|s|join|start)/)?
+    (\\d+)
+    (?<mode2>/(join|start|j|s|))?`,
+    'ix',
+  )
+  const matches = XRegExp.exec(url, zoomMeetingUrlRegex)
+  if (matches !== null && (matches.mode1 !== undefined || matches.mode2 !== undefined)) {
+    return true
   } else {
     return false
   }
@@ -25,20 +28,29 @@ export const isZoomMeetingUrl = (url: string): boolean => {
  * Generates a zoom web link from a valid zoom url
  */
 export const generateZoomWebLink = (validZoomUrl: string, urlPrefix: string = ''): string => {
-  const zoomMeetingUrlRegex = /^https?\:\/\/((?<subDomain>.*)\.)?zoom\.us\/(wc\/)?((?<mode1>(j|s|join|start))\/)?(?<zoomId>\d+)(\/(?<mode2>(join|start|j|s|))\/?)?(.*\?((.*\&)?pwd=(?<password>[a-z0-9]+)))?/i
-  const matches = zoomMeetingUrlRegex.exec(validZoomUrl)
+  const zoomMeetingUrlRegex = XRegExp(
+    `^https?://
+    ((?<subDomain>.*)\\.)?
+    zoom\\.us/
+    (wc/)?
+    ((?<mode1>(j|s|join|start))/)?
+    (?<zoomId>\\d+)
+    (/(?<mode2>(join|start|j|s|))\/?)?
+    (.*\\?((.*\\&)?pwd=(?<password>[a-z0-9]+)))?`,
+    'ix',
+  )
+  const matches = XRegExp.exec(validZoomUrl, zoomMeetingUrlRegex)
   if (
     matches !== null &&
-    matches.groups !== undefined &&
     // tslint:disable-next-line: strict-type-predicates
-    (matches.groups.mode1 !== undefined || matches.groups.mode2 !== undefined)
+    (matches.mode1 !== undefined || matches.mode2 !== undefined)
   ) {
     // tslint:disable-next-line: strict-type-predicates
-    const subDomain = matches.groups.subDomain !== undefined ? matches.groups.subDomain : urlPrefix
-    const zoomId = matches.groups.zoomId
-    const password = matches.groups.password
+    const subDomain = matches.subDomain !== undefined ? matches.subDomain : urlPrefix
+    const zoomId = matches.zoomId
+    const password = matches.password
     // tslint:disable-next-line: strict-type-predicates
-    let mode = matches.groups.mode1 !== undefined ? matches.groups.mode1 : matches.groups.mode2
+    let mode = matches.mode1 !== undefined ? matches.mode1 : matches.mode2
     mode = mode.length === 1 ? mode.replace('j', 'join').replace('s', 'start') : mode
     let zoomWebLink =
       subDomain === ''

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -16,13 +16,6 @@
     "webRequestBlocking",
     "*://*.zoom.us/*"
   ],
-  "browser_action": {
-    "default_icon": {
-      "64": "icon-128x128.png"
-    },
-    "default_popup": "actions/option_action/add_option_action.html",
-    "default_title": "my Options addon"
-  },
   "options_ui": {
     "chrome_style": true,
     "page": "options/options.html"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@sindresorhus/tsconfig",
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es6",
     "declaration": false,
     "moduleResolution": "node",
     "esModuleInterop": true


### PR DESCRIPTION
This PR fixes the problems with Firefox:
- The main problem was regex groups wwhich is a ES2018 feature and [not supported by firefox](https://caniuse.com/#search=regex%20named), thus url parsing was realized by using xregex
- Cleanup of artifact in `manifest.json`
- Added configuration information for firefox
- Changed compile target from `esnext` to `es6`, since this is the first version to support `Error` subclassing