### PR TITLE
Remove not required privacy permission

### DIFF
--- a/tools/firefox_manifest_append.ts
+++ b/tools/firefox_manifest_append.ts
@@ -17,7 +17,6 @@ const updateManifestFireFox = () => {
       },
     },
   }
-  originalManifest.permissions = [...originalManifest.permissions, 'privacy']
   const updatedManifest = { ...originalManifest, ...fireFoxSpecifficSettings }
   fs.writeFileSync(distManifestPath, JSON.stringify(updatedManifest))
 }


### PR DESCRIPTION
Removes privacy permission testing  artifact in FireFox manifest costumization.