### PR TITLE
Fix broken dialog in Firefox

### DIFF
--- a/source/reactComponents/utils.ts
+++ b/source/reactComponents/utils.ts
@@ -2,7 +2,12 @@ import { Theme, createMuiTheme } from '@material-ui/core/styles'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
 
 export const getTheme = (): Theme => {
-  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+  let prefersDarkMode = false
+  try {
+    prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+  } catch {
+    prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches
+  }
 
   const theme = createMuiTheme({
     palette: {


### PR DESCRIPTION
Using 'window.matchMedia' directly if  'useMediaQuery'  throws an error
For some reason, 'useMediaQuery'  causes an error in FireFox which causes the dialog not to render. 
The error message is
TypeError: 'matchMedia' called on an object that does not implement interface Window.