### PR TITLE
FIX Firefox broken React dialog

### DIFF
--- a/source/reactComponents/utils.ts
+++ b/source/reactComponents/utils.ts
@@ -4,9 +4,13 @@ import useMediaQuery from '@material-ui/core/useMediaQuery'
 export const getTheme = (): Theme => {
   let prefersDarkMode = false
   try {
-    prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+    prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark').matches
   } catch {
-    prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches
+    try {
+      prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+    } catch (error) {
+      console.log(`ZoomCognito: Failed to get color-scheme: ${error}`)
+    }
   }
 
   const theme = createMuiTheme({


### PR DESCRIPTION
Use `useMediaQuery` only if  `window.matchMedia` throws an error.
This Fixes the error in FireFox preventing the dialog from rendering.
Most likely this is due to content_scripts not getting a fully qualified window object, see
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts